### PR TITLE
Fixes warning while running the server

### DIFF
--- a/aldryn_people/forms.py
+++ b/aldryn_people/forms.py
@@ -10,6 +10,7 @@ from .models import Person
 class PersonForm(TranslatableModelForm):
     class Meta:
         model = Person
+        fields = '__all__'
 
     def clean_slug(self):
         return self.cleaned_data['slug'] or None


### PR DESCRIPTION
```
Users/finalangel/Sites/django-cms-demo/env/lib/python2.7/site-packages/parler/forms.py:163: RemovedInDjango18Warning: Creating a ModelForm without either the 'fields' attribute or the 'exclude' attribute is deprecated - form PersonForm needs updating
  return super(TranslatableModelFormMetaclass, mcs).__new__(mcs, name, bases, attrs)
```