### PR TITLE
Fixes/automatic slug handling of duplicates

### DIFF
--- a/aldryn_people/models.py
+++ b/aldryn_people/models.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 import base64
 import urlparse
-import aldryn_common
 import warnings
 import vobject
 
@@ -19,10 +18,15 @@ except ImportError:
     from django.template.defaultfilters import slugify
 
 from cms.models.pluginmodel import CMSPlugin
+
 from djangocms_text_ckeditor.fields import HTMLField
+
 from filer.fields.image import FilerImageField
+
 from parler.models import TranslatableModel, TranslatedFields
-import aldryn_common.admin_fields.sortedm2m
+
+from aldryn_common.slugs import unique_slugify
+from aldryn_common.admin_fields.sortedm2m import SortedM2MModelField
 
 from .utils import get_additional_styles
 
@@ -199,7 +203,7 @@ class Person(TranslatableModel):
 
     def save(self, **kwargs):
         if not self.slug:
-            self.slug = slugify(self.name)
+            unique_slugify(instance=self, value=self.name)
         return super(Person, self).save(**kwargs)
 
 
@@ -214,7 +218,7 @@ class BasePeoplePlugin(CMSPlugin):
     style = models.CharField(
         _('Style'), choices=STYLE_CHOICES,
         default=STYLE_CHOICES[0][0], max_length=50)
-    people = aldryn_common.admin_fields.sortedm2m.SortedM2MModelField(
+    people = SortedM2MModelField(
         Person, blank=True, null=True)
     group_by_group = models.BooleanField(
         verbose_name=_('group by group'),

--- a/aldryn_people/models.py
+++ b/aldryn_people/models.py
@@ -6,6 +6,8 @@ import urlparse
 import warnings
 import vobject
 
+import six
+
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.db import models
@@ -115,7 +117,11 @@ class Person(TranslatableModel):
         verbose_name_plural = _('People')
 
     def __str__(self):
-        return self.name
+        pkstr = str(self.pk)
+
+        if six.PY2:
+            pkstr = six.u(pkstr)
+        return self.name.strip() or pkstr
 
     @property
     def comment(self):

--- a/aldryn_people/models.py
+++ b/aldryn_people/models.py
@@ -121,7 +121,8 @@ class Person(TranslatableModel):
 
         if six.PY2:
             pkstr = six.u(pkstr)
-        return self.name.strip() or pkstr
+        name = self.name.strip()
+        return name if len(name) > 0 else pkstr
 
     @property
     def comment(self):

--- a/aldryn_people/tests/test_models.py
+++ b/aldryn_people/tests/test_models.py
@@ -56,6 +56,20 @@ class TestBasicPeopleModels(TransactionTestCase):
         person.save()
         self.assertEquals(person.slug, slug)
 
+    def test_auto_slugify_same_name(self):
+        name_1 = 'Melchior Hoffman'
+        slug_1 = 'melchior-hoffman'
+        person_1 = Person.objects.create(name=name_1)
+        person_1.save()
+
+        name_2 = 'Melchior Hoffman'
+        slug_2 = 'melchior-hoffman-2'
+        person_2 = Person.objects.create(name=name_2)
+        person_2.save()
+
+        self.assertEquals(person_1.slug, slug_1)
+        self.assertEquals(person_2.slug, slug_2)
+
 
 class TestBasicGroupModel(TransactionTestCase):
 


### PR DESCRIPTION
Fixed instances where adding a user with same first name and last name combination as another user caused an integrity error.

There's two tests that don't pass, they are unrelated to my change, I'm unable to look into them at the moment.