### PR TITLE
Fix people list plugin, add group-detail template.

### DIFF
--- a/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/includes/person.html
+++ b/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/includes/person.html
@@ -51,7 +51,7 @@
         <div class="lead">{{ person.description|safe }}</div>
     {% endif %}
 
-    {% if person.vcard_enabled %}
+    {% if not instance and person.vcard_enabled or instance.show_vcard and person.vcard_enabled %}
         <a href="{% url 'aldryn_people:download_vcard' person.slug %}" class="btn btn-default btn-sm">
             <span class="fa fa-fw fa-download" aria-hidden="true"></span>
             {% trans "Download vCard" %}

--- a/aldryn_people/boilerplates/legacy/templates/aldryn_people/group_detail.html
+++ b/aldryn_people/boilerplates/legacy/templates/aldryn_people/group_detail.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% load cms_tags i18n %}
+
+{% block title %}{{ group.name }} - {{ block.super }}{% endblock %}
+
+{% block content %}
+    <div class="aldryn aldryn-people aldryn-group-detail">
+        <h1>{% render_model group 'name' %}</h1>
+        {% for person in group.people.all %}
+            {% include "aldryn_people/includes/people_item.html" with person=person %}
+        {% endfor %}
+    </div>
+{% endblock content %}aldryn_people/boilerplates/legacy/templates/aldryn_people/group_detail.html

--- a/aldryn_people/boilerplates/legacy/templates/aldryn_people/includes/people_item.html
+++ b/aldryn_people/boilerplates/legacy/templates/aldryn_people/includes/people_item.html
@@ -11,7 +11,9 @@
 		{% if person.phone %}{% trans "Phone:" %} <span>{{ person.phone|phoneformat }}</span><br />{% endif %}
 		{% if person.mobile %}{% trans "Mobile:" %} <span>{{ person.mobile|phoneformat }}</span><br />{% endif %}
 		{% if person.email %}{% trans "E-Mail:" %} <a href="mailto:{{ person.email }}">{{ person.email }}</a>{% endif %}
-		{% if instance.show_vcard and person.vcard_enabled %}<br /><a href="{% url 'aldryn_people:download_vcard' person.slug %}" class="btn-download">{% trans "Download vCard" %}</a>{% endif %}
+		{% if not instance and person.vcard_enabled or instance.show_vcard and person.vcard_enabled %}
+            <br /><a href="{% url 'aldryn_people:download_vcard' person.slug %}" class="btn-download">{% trans "Download vCard" %}</a>
+        {% endif %}
 	</p>
 	{% if person.description %}<div class="people-desc">{{ person.description|safe }}</div>{% endif %}
 </div>


### PR DESCRIPTION
Plugin is using the same template as the view does, so it wasn't respecting plugin settings.
also legacy boilerplate didn't had group_detail template which caused an error, basicly it is the same as bootstrap except for using legacy people_item instead of bootstrap person include template.