### PR TITLE
Translate person name slug

### DIFF
--- a/aldryn_people/admin.py
+++ b/aldryn_people/admin.py
@@ -17,24 +17,31 @@ class PersonAdmin(AllTranslationsMixin, TranslatableAdmin):
     list_display = [
         '__str__', 'email', 'vcard_enabled', ]
     list_filter = ['groups', 'vcard_enabled']
-    search_fields = ('name', 'email', 'translations__function')
-    prepopulated_fields = {'slug': ('name',)}
+    search_fields = ('translations__name', 'email', 'translations__function')
     raw_id_fields = ('user',)
+
+    def get_prepopulated_fields(self, request, obj=None):
+        # Using method since these are translated fields
+        return {
+            'slug': ('name',)
+        }
 
     fieldsets = (
         (None, {
             'fields': (
-                'name', 'function', 'slug', 'visual', 'vcard_enabled'
+                ('name', 'slug', ),
+                'function', 'description',
             ),
         }),
-        (_('Contact'), {
+        (_('Contact (untranslated)'), {
             'fields': (
-                'phone', 'mobile', 'fax', 'email', 'website', 'user'
+                'visual', 'phone', 'mobile', 'fax', 'email', 'website',
+                'user', 'vcard_enabled'
             ),
         }),
         (None, {
             'fields': (
-                'groups', 'description',
+                'groups',
             ),
         }),
     )
@@ -45,20 +52,22 @@ class PersonAdmin(AllTranslationsMixin, TranslatableAdmin):
 class GroupAdmin(AllTranslationsMixin, TranslatableAdmin):
 
     list_display = ['__str__', 'city', ]
-    search_filter = ['name']
-
+    search_filter = ['translations__name']
     fieldsets = (
         (None, {
             'fields': (
-                'name', 'description', 'phone', 'fax', 'email', 'website'
+                ('name', 'slug', ),
+                'description',
             ),
         }),
-        (_('Address'), {
+        (_('Contact (untranslated)'), {
             'fields': (
+                'phone', 'fax', 'email', 'website',
                 'address', 'postal_code', 'city'
-            ),
+            )
         }),
     )
+
 
 admin.site.register(Person, PersonAdmin)
 admin.site.register(Group, GroupAdmin)

--- a/aldryn_people/cms_toolbar.py
+++ b/aldryn_people/cms_toolbar.py
@@ -54,9 +54,9 @@ class PeopleToolbar(CMSToolbar):
         user = getattr(self.request, 'user', None)
         if user:
             view_name = self.request.resolver_match.view_name
+            group = person = None
             if view_name == 'aldryn_people:group-detail':
                 group = get_obj_from_request(Group, self.request)
-                person = None
             elif view_name in [
                     'aldryn_people:person-detail',
                     'aldryn_people:download_vcard']:

--- a/aldryn_people/menu.py
+++ b/aldryn_people/menu.py
@@ -20,11 +20,13 @@ class PersonMenu(CMSAttachMenu):
     def get_nodes(self, request):
         nodes = []
         language = get_language_from_request(request, check_path=True)
-        persons = Person.objects.all().order_by('name')
+        persons = Person.objects.language(language)
 
         for person in persons:
             node = NavigationNode(
-                person.name,
+                person.safe_translation_getter(
+                    'name', default=_('person: {0}').format(person.pk),
+                    language_code=language),
                 person.get_absolute_url(language=language),
                 person.pk,
             )

--- a/aldryn_people/migrations/0009_auto_20150724_1654.py
+++ b/aldryn_people/migrations/0009_auto_20150724_1654.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aldryn_people', '0008_remove_person_group'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='person',
+            options={'ordering': ['name'], 'verbose_name': 'Person', 'verbose_name_plural': 'People'},
+        ),
+        migrations.AddField(
+            model_name='persontranslation',
+            name='name',
+            field=models.CharField(default='', help_text="Provide this person's name.", max_length=255, verbose_name='name'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='persontranslation',
+            name='slug',
+            field=models.SlugField(default='', help_text='Leave blank to auto-generate a unique slug.', max_length=255, verbose_name='slug'),
+            preserve_default=True,
+        ),
+    ]

--- a/aldryn_people/migrations/0010_auto_20150724_1654.py
+++ b/aldryn_people/migrations/0010_auto_20150724_1654.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import models, migrations
+
+
+def forwards_func(apps, schema_editor):
+    """
+    These translation objects probably already exist, so, we need to carefully
+    copy new field values into them.
+    """
+    Person = apps.get_model('aldryn_people', 'Person')
+    PersonTranslation = apps.get_model('aldryn_people', 'PersonTranslation')
+
+    for obj in Person.objects.all():
+        PersonTranslation.objects.update_or_create(
+            master_id=obj.pk,
+            language_code=settings.LANGUAGE_CODE,
+            defaults={
+                "name": obj.name,
+                "slug": obj.slug,
+            }
+        )
+
+
+def backwards_func(apps, schema_editor):
+    Person = apps.get_model('aldryn_people', 'Person')
+    PersonTranslation = apps.get_model('aldryn_people', 'PersonTranslation')
+
+    for obj in Person.objects.all():
+        translation = _get_translation(obj, PersonTranslation)
+        obj.name = translation.name
+        obj.slug = translation.slug
+        obj.save()
+
+
+def _get_translation(object, MyModelTranslation):
+    translations = MyModelTranslation.objects.filter(master_id=object.pk)
+    try:
+        # Try default translation
+        return translations.get(language_code=settings.LANGUAGE_CODE)
+    except ObjectDoesNotExist:
+        try:
+            # Try default language
+            return translations.get(language_code=settings.PARLER_DEFAULT_LANGUAGE_CODE)
+        except ObjectDoesNotExist:
+            # Maybe the object was translated only in a specific language?
+            # Hope there is a single translation
+            return translations.get()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aldryn_people', '0009_auto_20150724_1654'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, backwards_func),
+    ]

--- a/aldryn_people/migrations/0011_auto_20150724_1900.py
+++ b/aldryn_people/migrations/0011_auto_20150724_1900.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aldryn_people', '0010_auto_20150724_1654'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='person',
+            options={'verbose_name': 'Person', 'verbose_name_plural': 'People'},
+        ),
+        migrations.RemoveField(
+            model_name='person',
+            name='name',
+        ),
+        migrations.RemoveField(
+            model_name='person',
+            name='slug',
+        ),
+        migrations.AlterField(
+            model_name='grouptranslation',
+            name='name',
+            field=models.CharField(help_text="Provide this group's name.", max_length=255, verbose_name='name'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='grouptranslation',
+            name='slug',
+            field=models.SlugField(default='', max_length=255, blank=True, help_text='Leave blank to auto-generate a unique slug.', verbose_name='slug'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='persontranslation',
+            name='slug',
+            field=models.SlugField(default='', max_length=255, blank=True, help_text='Leave blank to auto-generate a unique slug.', verbose_name='unique slug'),
+            preserve_default=True,
+        ),
+    ]

--- a/aldryn_people/models.py
+++ b/aldryn_people/models.py
@@ -304,8 +304,8 @@ class Person(TranslatableModel):
             slugs = []
             all_slugs = (
                 Person.objects.language(lang)
-                             .exclude(pk=self.pk)
-                             .values_list('translations__slug', flat=True)
+                              .exclude(pk=self.pk)
+                              .values_list('translations__slug', flat=True)
             )
             for slug in all_slugs:
                 if slug and slug.startswith((self.name, self.slug)):

--- a/aldryn_people/models.py
+++ b/aldryn_people/models.py
@@ -21,7 +21,11 @@ from django.utils.translation import ugettext_lazy as _, ugettext, override
 
 from aldryn_common.admin_fields.sortedm2m import SortedM2MModelField
 from cms.models.pluginmodel import CMSPlugin
-from cms.utils.i18n import get_current_language, get_languages
+from cms.utils.i18n import (
+    get_current_language,
+    get_default_language,
+    get_languages,
+)
 from djangocms_text_ckeditor.fields import HTMLField
 from filer.fields.image import FilerImageField
 from parler.models import TranslatableModel, TranslatedFields
@@ -281,7 +285,7 @@ class Person(TranslatableModel):
         return vcard.serialize()
 
     def save(self, **kwargs):
-        language = self.get_current_language()
+        language = self.get_current_language() or get_default_language()
         if not self.slug:
             self.slug = force_unicode(django_slugify(self.name))
         # If there is still no slug, we must give it something to start with

--- a/aldryn_people/models.py
+++ b/aldryn_people/models.py
@@ -207,11 +207,6 @@ class Person(TranslatableModel):
             return reverse('aldryn_people:person-detail', kwargs=kwargs)
 
     def get_vcard(self, request=None):
-        if self.primary_group:
-            group_name = self.primary_group.safe_translation_getter(
-                'name', default="Group: {0}".format(self.primary_group.pk))
-        else:
-            group_name = ''
         function = self.safe_translation_getter('function')
 
         vcard = vobject.vCard()
@@ -256,6 +251,8 @@ class Person(TranslatableModel):
             website.value = unicode(self.website)
 
         if self.primary_group:
+            group_name = self.primary_group.safe_translation_getter(
+                'name', default="Group: {0}".format(self.primary_group.pk))
             if group_name:
                 vcard.add('org').value = [group_name]
             if (self.primary_group.address or self.primary_group.city or

--- a/aldryn_people/south_migrations/0024_auto__add_field_persontranslation_name__add_field_persontranslation_sl.py
+++ b/aldryn_people/south_migrations/0024_auto__add_field_persontranslation_name__add_field_persontranslation_sl.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'PersonTranslation.name'
+        db.add_column(u'aldryn_people_person_translation', 'name',
+                      self.gf('django.db.models.fields.CharField')(default=u'', max_length=255),
+                      keep_default=False)
+
+        # Adding field 'PersonTranslation.slug'
+        db.add_column(u'aldryn_people_person_translation', 'slug',
+                      self.gf('django.db.models.fields.SlugField')(default=u'', max_length=255),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'PersonTranslation.name'
+        db.delete_column(u'aldryn_people_person_translation', 'name')
+
+        # Deleting field 'PersonTranslation.slug'
+        db.delete_column(u'aldryn_people_person_translation', 'slug')
+
+
+    models = {
+        u'aldryn_people.group': {
+            'Meta': {'object_name': 'Group'},
+            'address': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_people.grouptranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'GroupTranslation', 'db_table': "u'aldryn_people_group_translation'"},
+            'description': ('djangocms_text_ckeditor.fields.HTMLField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_people.Group']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'default': "u''", 'max_length': '255'})
+        },
+        u'aldryn_people.peopleplugin': {
+            'Meta': {'object_name': 'PeoplePlugin'},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'group_by_group': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'people': ('aldryn_common.admin_fields.sortedm2m.SortedM2MModelField', [], {'symmetrical': 'False', 'to': u"orm['aldryn_people.Person']", 'null': 'True', 'blank': 'True'}),
+            'show_links': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_vcard': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'style': ('django.db.models.fields.CharField', [], {'default': "u'standard'", 'max_length': '50'})
+        },
+        u'aldryn_people.person': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'Person'},
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'groups': ('sortedm2m.fields.SortedManyToManyField', [], {'default': 'None', 'related_name': "u'people'", 'blank': 'True', 'symmetrical': 'False', 'to': u"orm['aldryn_people.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'persons'", 'unique': 'True', 'null': 'True', 'to': u"orm['auth.User']"}),
+            'vcard_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'visual': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['filer.Image']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_people.persontranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'PersonTranslation', 'db_table': "u'aldryn_people_person_translation'"},
+            'description': ('djangocms_text_ckeditor.fields.HTMLField', [], {'default': "u''", 'blank': 'True'}),
+            'function': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_people.Person']"}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'default': "u''", 'max_length': '255'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set+'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'filer.image': {
+            'Meta': {'object_name': 'Image'},
+            '_height': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            '_width': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_taken': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'default_alt_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'default_caption': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'file_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['filer.File']", 'unique': 'True', 'primary_key': 'True'}),
+            'must_always_publish_author_credit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'must_always_publish_copyright': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subject_location': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '64', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['aldryn_people']

--- a/aldryn_people/south_migrations/0025_migrate_translatable_fields.py
+++ b/aldryn_people/south_migrations/0025_migrate_translatable_fields.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import models
+
+
+def _get_translation(obj, MyModelTranslation):
+    translations = MyModelTranslation.objects.filter(master_id=obj.pk)
+    try:
+        # Try default translation
+        return translations.get(language_code=settings.LANGUAGE_CODE)
+    except ObjectDoesNotExist:
+        try:
+            # Try default language
+            return translations.get(language_code=settings.PARLER_DEFAULT_LANGUAGE_CODE)
+        except ObjectDoesNotExist:
+            # Maybe the object was translated only in a specific language?
+            # Hope there is a single translation
+            return translations.get()
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        """
+        These translation objects probably already exist, so, we need to
+        carefully copy new field values into them.
+        """
+        Person = orm['aldryn_people.Person']
+        PersonTranslation = orm['aldryn_people.PersonTranslation']
+
+        for obj in Person.objects.all():
+            trans_obj, created = PersonTranslation.objects.get_or_create(
+                master_id=obj.pk,
+                language_code=settings.LANGUAGE_CODE,
+            )
+            trans_obj.name = obj.name
+            trans_obj.slug = obj.slug
+            trans_obj.save()
+
+    def backwards(self, orm):
+        # Convert all fields back to the single-language table.
+        Person = orm['aldryn_people.Person']
+        PersonTranslation = orm['aldryn_people.PersonTranslation']
+
+        for obj in Person.objects.all():
+            translation = _get_translation(obj, PersonTranslation)
+            obj.name = translation.name
+            obj.slug = translation.slug
+            obj.save()   # Note this only calls Model.save() in South.
+
+    models = {
+        u'aldryn_people.group': {
+            'Meta': {'object_name': 'Group'},
+            'address': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_people.grouptranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'GroupTranslation', 'db_table': "u'aldryn_people_group_translation'"},
+            'description': ('djangocms_text_ckeditor.fields.HTMLField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_people.Group']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'default': "u''", 'max_length': '255'})
+        },
+        u'aldryn_people.peopleplugin': {
+            'Meta': {'object_name': 'PeoplePlugin'},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'group_by_group': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'people': ('aldryn_common.admin_fields.sortedm2m.SortedM2MModelField', [], {'symmetrical': 'False', 'to': u"orm['aldryn_people.Person']", 'null': 'True', 'blank': 'True'}),
+            'show_links': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_vcard': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'style': ('django.db.models.fields.CharField', [], {'default': "u'standard'", 'max_length': '50'})
+        },
+        u'aldryn_people.person': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'Person'},
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'groups': ('sortedm2m.fields.SortedManyToManyField', [], {'default': 'None', 'related_name': "u'people'", 'blank': 'True', 'symmetrical': 'False', 'to': u"orm['aldryn_people.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'persons'", 'unique': 'True', 'null': 'True', 'to': u"orm['auth.User']"}),
+            'vcard_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'visual': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['filer.Image']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_people.persontranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'PersonTranslation', 'db_table': "u'aldryn_people_person_translation'"},
+            'description': ('djangocms_text_ckeditor.fields.HTMLField', [], {'default': "u''", 'blank': 'True'}),
+            'function': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_people.Person']"}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'default': "u''", 'max_length': '255'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set+'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'filer.image': {
+            'Meta': {'object_name': 'Image'},
+            '_height': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            '_width': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_taken': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'default_alt_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'default_caption': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'file_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['filer.File']", 'unique': 'True', 'primary_key': 'True'}),
+            'must_always_publish_author_credit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'must_always_publish_copyright': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subject_location': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '64', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['aldryn_people']
+    symmetrical = True

--- a/aldryn_people/south_migrations/0026_auto__del_field_person_slug__del_field_person_name.py
+++ b/aldryn_people/south_migrations/0026_auto__del_field_person_slug__del_field_person_name.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Person.slug'
+        db.delete_column(u'aldryn_people_person', 'slug')
+
+        # Deleting field 'Person.name'
+        db.delete_column(u'aldryn_people_person', 'name')
+
+
+    def backwards(self, orm):
+        # Adding field 'Person.slug'
+        db.add_column(u'aldryn_people_person', 'slug',
+                      self.gf('django.db.models.fields.CharField')(unique=True, max_length=255, null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Person.name'
+        db.add_column(u'aldryn_people_person', 'name',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=255),
+                      keep_default=False)
+
+
+    models = {
+        u'aldryn_people.group': {
+            'Meta': {'object_name': 'Group'},
+            'address': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_people.grouptranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'GroupTranslation', 'db_table': "u'aldryn_people_group_translation'"},
+            'description': ('djangocms_text_ckeditor.fields.HTMLField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_people.Group']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'default': "u''", 'max_length': '255'})
+        },
+        u'aldryn_people.peopleplugin': {
+            'Meta': {'object_name': 'PeoplePlugin'},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'group_by_group': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'people': ('aldryn_common.admin_fields.sortedm2m.SortedM2MModelField', [], {'symmetrical': 'False', 'to': u"orm['aldryn_people.Person']", 'null': 'True', 'blank': 'True'}),
+            'show_links': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'show_vcard': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'style': ('django.db.models.fields.CharField', [], {'default': "u'standard'", 'max_length': '50'})
+        },
+        u'aldryn_people.person': {
+            'Meta': {'object_name': 'Person'},
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'groups': ('sortedm2m.fields.SortedManyToManyField', [], {'default': 'None', 'related_name': "u'people'", 'blank': 'True', 'symmetrical': 'False', 'to': u"orm['aldryn_people.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'persons'", 'unique': 'True', 'null': 'True', 'to': u"orm['auth.User']"}),
+            'vcard_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'visual': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['filer.Image']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_people.persontranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'PersonTranslation', 'db_table': "u'aldryn_people_person_translation'"},
+            'description': ('djangocms_text_ckeditor.fields.HTMLField', [], {'default': "u''", 'blank': 'True'}),
+            'function': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_people.Person']"}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'default': "u''", 'max_length': '255'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set+'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'filer.image': {
+            'Meta': {'object_name': 'Image'},
+            '_height': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            '_width': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_taken': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'default_alt_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'default_caption': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'file_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['filer.File']", 'unique': 'True', 'primary_key': 'True'}),
+            'must_always_publish_author_credit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'must_always_publish_copyright': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subject_location': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '64', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['aldryn_people']

--- a/aldryn_people/tests/__init__.py
+++ b/aldryn_people/tests/__init__.py
@@ -34,12 +34,15 @@ class BasePeopleTest(BaseCMSTestCase, TestCase):
             'de': {'name': 'Gruppe2', 'description': 'Beschreibung2'},
         },
         'person1': {
-            'en': {'function': 'function1', 'description': 'description-en'},
-            'de': {'function': 'Funktion1', 'description': 'Beschreibung-de'},
+            'en': {'name': 'person1', 'slug': 'person1',
+                   'function': 'function1', 'description': 'description-en'},
+            'de': {'name': 'mensch1', 'slug': 'mensch1',
+                   'function': 'Funktion1', 'description': 'Beschreibung-de'},
         },
         'person2': {
             # This should *not* have a EN translation
-            'de': {'function': 'Funktion2', 'description': 'Beschreibung2'},
+            'de': {'name': 'mensch2', 'slug': 'mensch2',
+                   'function': 'Funktion2', 'description': 'Beschreibung2'},
         },
     }
 

--- a/aldryn_people/tests/test_models.py
+++ b/aldryn_people/tests/test_models.py
@@ -23,9 +23,9 @@ class TestBasicPeopleModels(TransactionTestCase):
     def test_delete_person(self):
         """We can delete a person."""
         name = 'Person Delete'
-        Person.objects.create(name=name)
-        Person.objects.get(name=name).delete()
-        self.assertFalse(Person.objects.filter(name=name))
+        person = Person.objects.create(name=name)
+        Person.objects.get(pk=person.pk).delete()
+        self.assertFalse(Person.objects.filter(pk=person.pk))
 
     def test_str(self):
         name = 'Person Str'
@@ -63,7 +63,7 @@ class TestBasicPeopleModels(TransactionTestCase):
         person_1.save()
 
         name_2 = 'Melchior Hoffman'
-        slug_2 = 'melchior-hoffman-2'
+        slug_2 = 'melchior-hoffman_1'
         person_2 = Person.objects.create(name=name_2)
         person_2.save()
 
@@ -162,7 +162,7 @@ class TestPersonModelTranslation(BasePeopleTest):
         )
         # Ensure this works for other langs too
         person1 = self.reload(self.person1, 'de')
-        vcard_de = 'BEGIN:VCARD\r\nVERSION:3.0\r\nADR;TYPE=WORK:;;123 Main Street;Anytown;;12345;\r\nEMAIL:person@org.org\r\nFN:person1\r\nN:;person1;;;\r\nORG:Gruppe1\r\nTEL;TYPE=WORK:+1 (234) 567-8900\r\nTEL;TYPE=CELL:+1 (234) 567-8901\r\nTEL;TYPE=FAX:+1 (234) 567-8902\r\nTEL;TYPE=WORK:+1 (234) 567-8903\r\nTEL;TYPE=FAX:+1 (234) 567-8904\r\nTITLE:Funktion1\r\nURL:www.website.com\r\nURL:www.groupwebsite.com\r\nEND:VCARD\r\n'  # flake8: noqa
+        vcard_de = 'BEGIN:VCARD\r\nVERSION:3.0\r\nADR;TYPE=WORK:;;123 Main Street;Anytown;;12345;\r\nEMAIL:person@org.org\r\nFN:mensch1\r\nN:;mensch1;;;\r\nORG:Gruppe1\r\nTEL;TYPE=WORK:+1 (234) 567-8900\r\nTEL;TYPE=CELL:+1 (234) 567-8901\r\nTEL;TYPE=FAX:+1 (234) 567-8902\r\nTEL;TYPE=WORK:+1 (234) 567-8903\r\nTEL;TYPE=FAX:+1 (234) 567-8904\r\nTITLE:Funktion1\r\nURL:www.website.com\r\nURL:www.groupwebsite.com\r\nEND:VCARD\r\n'  # flake8: noqa
         with override('de'):
             self.assertEqual(
                 person1.get_vcard(),

--- a/aldryn_people/views.py
+++ b/aldryn_people/views.py
@@ -11,26 +11,6 @@ from parler.views import TranslatableSlugMixin
 from .models import Group, Person
 
 
-class DownloadVcardView(DetailView):
-    model = Person
-
-    def get(self, request, *args, **kwargs):
-        person = self.get_object()
-        if not person.vcard_enabled:
-            raise Http404
-
-        filename = "%s.vcf" % person.name
-        vcard = person.get_vcard(request)
-        try:
-            vcard = vcard.decode('utf-8').encode('ISO-8859-1')
-        except:
-            pass
-        response = HttpResponse(vcard, content_type="text/x-vCard")
-        response['Content-Disposition'] = 'attachment; filename="{0}"'.format(
-            filename)
-        return response
-
-
 class LanguageChangerMixin(object):
     """
     Convenience mixin that adds CMS Language Changer support.
@@ -62,7 +42,28 @@ class AllowPKsTooMixin(object):
         return super(AllowPKsTooMixin, self).get_object(queryset)
 
 
-class PersonDetailView(LanguageChangerMixin, DetailView):
+class DownloadVcardView(AllowPKsTooMixin, TranslatableSlugMixin, DetailView):
+    model = Person
+
+    def get(self, request, *args, **kwargs):
+        person = self.get_object()
+        if not person.vcard_enabled:
+            raise Http404
+
+        filename = "%s.vcf" % person.name
+        vcard = person.get_vcard(request)
+        try:
+            vcard = vcard.decode('utf-8').encode('ISO-8859-1')
+        except:
+            pass
+        response = HttpResponse(vcard, content_type="text/x-vCard")
+        response['Content-Disposition'] = 'attachment; filename="{0}"'.format(
+            filename)
+        return response
+
+
+class PersonDetailView(LanguageChangerMixin, AllowPKsTooMixin,
+                       TranslatableSlugMixin, DetailView):
     model = Person
 
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -103,6 +103,7 @@ HELPER_SETTINGS = {
             {'code': 'en', },
         ),
         'default': {
+            'fallback': 'en',
             'hide_untranslated': True,  # PLEASE DO NOT CHANGE THIS
         }
     },


### PR DESCRIPTION
Addresses the 3rd point in #22 

Convert Person.name and .slug to be translated fields

Also includes improvements to admin for both person and group for clarity about which fields are translated and which are not.

Uses a 3-step process (create new fields, move existing data, remove old fields) to migrate existing data for both South and Django migrations.