### PR TITLE
Adds context and template to show ungrouped on main root view

### DIFF
--- a/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/group_list.html
+++ b/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/group_list.html
@@ -10,5 +10,11 @@
                 {% include "aldryn_people/includes/person.html" with person=person %}
             {% endfor %}
         {% endfor %}
+        {% if ungrouped_people.count %}
+            <h2>{% trans "Ungrouped" %}</h2>
+            {% for person in ungrouped_people %}
+                {% include "aldryn_people/includes/person.html" with person=person %}
+            {% endfor %}
+        {% endif %}
     </div>
 {% endblock content %}

--- a/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/group_list.html
+++ b/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/group_list.html
@@ -10,7 +10,7 @@
                 {% include "aldryn_people/includes/person.html" with person=person %}
             {% endfor %}
         {% endfor %}
-        {% if ungrouped_people.count %}
+        {% if ungrouped_people %}
             <h2>{% trans "Ungrouped" %}</h2>
             {% for person in ungrouped_people %}
                 {% include "aldryn_people/includes/person.html" with person=person %}

--- a/aldryn_people/views.py
+++ b/aldryn_people/views.py
@@ -77,7 +77,6 @@ class GroupListView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super(GroupListView, self).get_context_data(**kwargs)
-        context['ungrouped_people'] = Person.objects\
-                                            .filter(groups__isnull=True)\
-                                            .all()
+        context['ungrouped_people'] = Person.objects.filter(
+            groups__isnull=True)
         return context

--- a/aldryn_people/views.py
+++ b/aldryn_people/views.py
@@ -74,3 +74,10 @@ class GroupDetailView(LanguageChangerMixin, AllowPKsTooMixin,
 
 class GroupListView(ListView):
     model = Group
+
+    def get_context_data(self, **kwargs):
+        context = super(GroupListView, self).get_context_data(**kwargs)
+        context['ungrouped_people'] = Person.objects\
+                                            .filter(groups__isnull=True)\
+                                            .all()
+        return context


### PR DESCRIPTION
This simple adds context to the view and supporting markup to show ungrouped people on the main, root app view. This is done for comparable results with the plugin which has this as an option. By adding this, the implementer of the plugin can easily modify the template to use, or not use the context, but at least this context is available for those who do want to show ungrouped people.