### PR TITLE
Error in Aldryn Config File

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -18,6 +18,8 @@ class Form(forms.BaseForm):
 
     def to_settings(self, data, settings):
         settings['PEOPLE_PLUGIN_STYLES'] = data.get('people_plugin_styles', '')
-        settings['ALDRYN_PEOPLE_USER_THRESHOLD'] = int(data.get(
-            'user_threshold', 50))
+        try:
+            settings['ALDRYN_PEOPLE_USER_THRESHOLD'] = int(data.get('user_threshold'))
+        except (ValueError, TypeError):
+            pass
         return settings


### PR DESCRIPTION
A recent change introduced in the ``aldryn_config.py`` file (https://github.com/aldryn/aldryn-people/commit/175e8d063cc2d8a9482f737079c091e6ea64c277). This change makes it impossible to skip the "*Once there are this many users, change drop-down to ID input field*" field since the input ``''`` is forced to be an int which is not a valid argument for ``int()``:
```python
>>> int('')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid literal for int() with base 10: ''
```

The error on Aldryn Form validation itself:
```python
Traceback (most recent call last):
  File "./app.py", line 61, in provide
    output = handler(module.Form, payload)
  File "./app.py", line 82, in handle_action_savesettings
    return form.to_settings(payload['data'], payload['settings'])
  File "/tmp/tmpneIHaS/aldryn_config.py", line 22, in to_settings
    'user_threshold', 50))
ValueError: invalid literal for int() with base 10: ''
```

the code snippet causing the error
```python
# https://github.com/aldryn/aldryn-people/blob/master/aldryn_config.py
settings['ALDRYN_PEOPLE_USER_THRESHOLD'] = int(data.get('user_threshold', 50))
```