### PR TITLE
Templates, legacy: fix incorrect include, respect groups and ungrouped

### DIFF
--- a/aldryn_people/boilerplates/legacy/templates/aldryn_people/group_list.html
+++ b/aldryn_people/boilerplates/legacy/templates/aldryn_people/group_list.html
@@ -3,12 +3,21 @@
 
 {% block content %}
     <div class="aldryn aldryn-people aldryn-group-list">
-        <h1>{% trans "Groups" %}</h1>
-        {% for group in group_list %}
-            <h2>{% render_model group 'name' %}</h2>
-            {% for person in group.people.all|dictsort:"name" %}
-                {% include "aldryn_people/includes/person.html" with person=person %}
+        {% if group_list %}
+            <h1>{% trans "Groups" %}</h1>
+            {% for group in group_list %}
+                <h2>{% render_model group 'name' %}</h2>
+                {% for person in group.people.all|dictsort:"name" %}
+                    {% include "aldryn_people/includes/people_item.html" with person=person %}
+                {% endfor %}
             {% endfor %}
-        {% endfor %}
+        {% endif %}
+
+        {% if ungrouped_people %}
+            <h2>{% trans "Ungrouped" %}</h2>
+            {% for person in ungrouped_people %}
+                {% include "aldryn_people/includes/people_item.html" with person=person %}
+            {% endfor %}
+        {% endif %}
     </div>
 {% endblock content %}


### PR DESCRIPTION
Legacy template had an incorrect include statement and did not displayed people that weren't assigned to any group.

Related issue is #75 (either partially or fully fixed)