### PR TITLE
Add Python 3 compatibility by removing vobject, and generating raw vCard instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
     - secure: oJG/hKhutnzSFCSF8xUuMWmTxeuRp2eU9HBi/7JWVxd3AwDkKu3jtldQ0Vg/2iSofRzzG0wZpUKdgGa4ObOpOou5wWtq68OAVbJkHAtOB7U3HR4deVuQRZdR8GXWWS9G+H1B8PbFCVPzQrsnxHs/k0oBLUgAW8XfFfkhzzYGFKk=
   matrix:
     - TOXENV=flake8
+    - TOXENV=py34-dj18-cms31-fe
+    - TOXENV=py34-dj17-cms31-fe
+    - TOXENV=py34-dj17-cms30-fe
     - TOXENV=py27-dj18-cms31-fe
     - TOXENV=py27-dj17-cms31-fe
     - TOXENV=py27-dj17-cms30-fe

--- a/aldryn_people/cms_toolbar.py
+++ b/aldryn_people/cms_toolbar.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from django.utils.translation import ugettext as _, get_language_from_request
+from six import iteritems
 
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
@@ -49,7 +50,7 @@ def get_admin_url(action, action_args=[], **url_args):
     """
     base_url = admin_reverse(action, args=action_args)
     # Converts [{key: value}, …] => ["key=value", …]
-    url_arg_list = sorted(url_args.iteritems())
+    url_arg_list = sorted(iteritems(url_args))
     params = ["=".join([str(k), str(v)]) for (k, v) in url_arg_list]
     if params:
         return "?".join([base_url, "&".join(params)])

--- a/aldryn_people/tests/test_models.py
+++ b/aldryn_people/tests/test_models.py
@@ -154,14 +154,44 @@ class TestPersonModelTranslation(BasePeopleTest):
         person1.fax = '+1 (234) 567-8902'
         person1.website = 'www.website.com'
         person1.save()
-        vcard_en = 'BEGIN:VCARD\r\nVERSION:3.0\r\nADR;TYPE=WORK:;;123 Main Street;Anytown;;12345;\r\nEMAIL:person@org.org\r\nFN:person1\r\nN:;person1;;;\r\nORG:group1\r\nTEL;TYPE=WORK:+1 (234) 567-8900\r\nTEL;TYPE=CELL:+1 (234) 567-8901\r\nTEL;TYPE=FAX:+1 (234) 567-8902\r\nTEL;TYPE=WORK:+1 (234) 567-8903\r\nTEL;TYPE=FAX:+1 (234) 567-8904\r\nTITLE:function1\r\nURL:www.website.com\r\nURL:www.groupwebsite.com\r\nEND:VCARD\r\n'  # flake8: noqa
+        vcard_en = ('BEGIN:VCARD\r\n'
+                    'VERSION:3.0\r\n'
+                    'FN:person1\r\n'
+                    'N:;person1;;;\r\n'
+                    'EMAIL:person@org.org\r\n'
+                    'TITLE:function1\r\n'
+                    'TEL;TYPE=WORK:+1 (234) 567-8900\r\n'
+                    'TEL;TYPE=CELL:+1 (234) 567-8901\r\n'
+                    'TEL;TYPE=FAX:+1 (234) 567-8902\r\n'
+                    'URL:www.website.com\r\n'
+                    'ORG:group1\r\n'
+                    'ADR;TYPE=WORK:;;123 Main Street;Anytown;;12345;\r\n'
+                    'TEL;TYPE=WORK:+1 (234) 567-8903\r\n'
+                    'TEL;TYPE=FAX:+1 (234) 567-8904\r\n'
+                    'URL:www.groupwebsite.com\r\n'
+                    'END:VCARD\r\n')
         self.assertEqual(
             person1.get_vcard(),
             vcard_en
         )
         # Ensure this works for other langs too
         person1 = self.reload(self.person1, 'de')
-        vcard_de = 'BEGIN:VCARD\r\nVERSION:3.0\r\nADR;TYPE=WORK:;;123 Main Street;Anytown;;12345;\r\nEMAIL:person@org.org\r\nFN:mensch1\r\nN:;mensch1;;;\r\nORG:Gruppe1\r\nTEL;TYPE=WORK:+1 (234) 567-8900\r\nTEL;TYPE=CELL:+1 (234) 567-8901\r\nTEL;TYPE=FAX:+1 (234) 567-8902\r\nTEL;TYPE=WORK:+1 (234) 567-8903\r\nTEL;TYPE=FAX:+1 (234) 567-8904\r\nTITLE:Funktion1\r\nURL:www.website.com\r\nURL:www.groupwebsite.com\r\nEND:VCARD\r\n'  # flake8: noqa
+        vcard_de = ('BEGIN:VCARD\r\n'
+                    'VERSION:3.0\r\n'
+                    'FN:mensch1\r\n'
+                    'N:;mensch1;;;\r\n'
+                    'EMAIL:person@org.org\r\n'
+                    'TITLE:Funktion1\r\n'
+                    'TEL;TYPE=WORK:+1 (234) 567-8900\r\n'
+                    'TEL;TYPE=CELL:+1 (234) 567-8901\r\n'
+                    'TEL;TYPE=FAX:+1 (234) 567-8902\r\n'
+                    'URL:www.website.com\r\n'
+                    'ORG:Gruppe1\r\n'
+                    'ADR;TYPE=WORK:;;123 Main Street;Anytown;;12345;\r\n'
+                    'TEL;TYPE=WORK:+1 (234) 567-8903\r\n'
+                    'TEL;TYPE=FAX:+1 (234) 567-8904\r\n'
+                    'URL:www.groupwebsite.com\r\n'
+                    'END:VCARD\r\n')
         with override('de'):
             self.assertEqual(
                 person1.get_vcard(),

--- a/aldryn_people/vcard.py
+++ b/aldryn_people/vcard.py
@@ -1,0 +1,37 @@
+from itertools import chain
+from re import sub
+from six import iteritems, string_types
+
+
+class Vcard(object):
+    def __init__(self):
+        self.lines = []
+
+    def add_line(self, key, value, **params):
+        key_and_params = ';'.join(chain(
+            (key,),
+            ('{0}={1}'.format(k, v) for k, v in iteritems(params)),
+        ))
+
+        if isinstance(value, string_types):
+            value = self.__escape(value)
+        else:
+            value = ';'.join(self.__escape(x) for x in value)
+
+        line = '{0}:{1}'.format(key_and_params, value)
+        self.lines.append(line)
+
+    def __escape(self, value):
+        if value is None:
+            return ''
+        value = sub(r'[\;,"]', r'\\\0', value)
+        return value.replace('\r', r'\r').replace('\n', r'\n')
+
+    def __wrap_logical_line(self, line):
+        return '\r\n '.join(line[i:i + 75] for i in range(0, len(line), 75))
+
+    def __str__(self):
+        lines = chain(('BEGIN:VCARD', 'VERSION:3.0'),
+                      self.lines,
+                      ('END:VCARD', ''))
+        return '\r\n'.join(self.__wrap_logical_line(x) for x in lines)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ REQUIREMENTS = [
     'djangocms-text-ckeditor',
     'easy-thumbnails',
     'phonenumbers',
-    'vobject',
+    'six',
 
     # DO NOT REMOVE THE FOLLOWING, IT IS REQUIRED FOR EXISTING MIGRATIONS
     'django-phonenumber-field>=0.7.2',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     flake8
-    py27-dj18-cms31
+    {py27,py34}-dj18-cms31
+    py34-dj17-cms{31,30}
     py27-dj{17,16}-cms{31,30}
     py26-dj16-cms{31,30}
 
@@ -37,6 +38,7 @@ deps =
 basepython =
     py26: python2.6
     py27: python2.7
+    py34: python3.4
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
Hi,

I'd already started work on a Python 3 site before discovering we'd need to use this (actually, aldryn-newsblog which depends on this), so I've written a patch to make it work with Python 3, fixing #28.

It turns out there's no Python 3 compatible libraries that will generate vCard (that I could find, anyway), so instead I've resorted to just generating vCard from scratch.