### PR TITLE
Fix typo in plugin people grouping.

### DIFF
--- a/aldryn_people/cms_plugins.py
+++ b/aldryn_people/cms_plugins.py
@@ -45,9 +45,9 @@ class PeoplePlugin(CMSPluginBase):
     def group_people(self, people):
         groups = defaultdict(list)
 
-        for people in people:
-            for group in people.groups.all():
-                groups[group].append(people)
+        for person in people:
+            for group in person.groups.all():
+                groups[group].append(person)
 
         # Fixes a template resolution-related issue. See:
         # http://stackoverflow.com/questions/4764110/django-template-cant-loop-defaultdict  # noqa


### PR DESCRIPTION
Does not really affects the behavior but it is better to fix now, then have bugs later.