### PR TITLE
Fix vCard with image generation, adjust tox.ini envlist

### DIFF
--- a/aldryn_people/models.py
+++ b/aldryn_people/models.py
@@ -23,7 +23,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.importlib import import_module
-from django.utils.translation import ugettext_lazy as _, override
+from django.utils.translation import ugettext_lazy as _, override, force_text
 from six import text_type
 
 from aldryn_common.admin_fields.sortedm2m import SortedM2MModelField
@@ -260,7 +260,7 @@ class Person(TranslatedAutoSlugifyMixin, TranslatableModel):
             ext = self.visual.extension.upper()
             try:
                 with open(self.visual.path, 'rb') as f:
-                    data = base64.b64encode(f.read())
+                    data = force_text(base64.b64encode(f.read()))
                     vcard.add_line('PHOTO', data, TYPE=ext, ENCODING='b')
             except IOError:
                 if request:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     flake8
-    {py27,py34}-dj18-cms31
+    py{34,27}-dj18-cms31
     py34-dj17-cms{31,30}
     py27-dj{17,16}-cms{31,30}
     py26-dj16-cms{31,30}


### PR DESCRIPTION
* Fixes issue with treating encoded image as bytes instead of string.
* Adjust tox.ini env list to more general approach for versioning (minor change).