### PR TITLE
Use safe_translation_getter for name

### DIFF
--- a/aldryn_people/models.py
+++ b/aldryn_people/models.py
@@ -216,7 +216,7 @@ class Person(TranslationHelperMixin, TranslatedAutoSlugifyMixin,
 
         if six.PY2:
             pkstr = six.u(pkstr)
-        name = self.name.strip()
+        name = self.safe_translation_getter('name', default='', any_language=True).strip()
         return name if len(name) > 0 else pkstr
 
     @property


### PR DESCRIPTION
This returns an error if the user does not have a name in some languages, but in most cases, any fallback is ok.
If ``self.name`` returns error you may end up with the attached newsblog changeform which is not very informative
![aigor2](https://cloud.githubusercontent.com/assets/714711/11189477/9744f354-8c90-11e5-8f16-1c4f8de5f31e.png)
