### PR TITLE
Fix integration tests for 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,20 +17,20 @@ env:
     #                different Python ENVs if possible.
     # NOTE: FE-TESTS ARE DISABLED UNTIL THEY ARE FIXED FOR CMS 3.2
     - TOXENV=flake8
-    - TOXENV=py34-dj18-cms32
+    - TOXENV=py34-dj18-cms32-fe
     - TOXENV=py34-dj18-cms31
     - TOXENV=py27-dj18-cms32
     - TOXENV=py27-dj18-cms31
     - TOXENV=py34-dj17-cms32
     - TOXENV=py34-dj17-cms31
     - TOXENV=py34-dj17-cms30
-    - TOXENV=py27-dj17-cms32
+    - TOXENV=py27-dj17-cms32-fe
     - TOXENV=py27-dj17-cms31
     - TOXENV=py27-dj17-cms30
     - TOXENV=py27-dj16-cms32
     - TOXENV=py27-dj16-cms31
     - TOXENV=py27-dj16-cms30
-    - TOXENV=py26-dj16-cms32
+    - TOXENV=py26-dj16-cms32-fe
     - TOXENV=py26-dj16-cms31
     - TOXENV=py26-dj16-cms30
 

--- a/aldryn_people/tests/frontend/integration/pages/page.people.crud.js
+++ b/aldryn_people/tests/frontend/integration/pages/page.people.crud.js
@@ -4,39 +4,40 @@
  */
 
 'use strict';
-/* global element, by, expect */
+/* global browser, by, element, expect */
 
 // #############################################################################
 // INTEGRATION TEST PAGE OBJECT
 
-var cmsProtractorHelper = require('cms-protractor-helper');
-
-var peoplePage = {
+var page = {
     site: 'http://127.0.0.1:8000/en/',
 
     // log in
     editModeLink: element(by.css('.inner a[href="/?edit"]')),
-    usernameInput: element(by.id('id_cms-username')),
-    passwordInput: element(by.id('id_cms-password')),
-    loginButton: element(by.css('.cms_form-login input[type="submit"]')),
-    userMenus: element.all(by.css('.cms_toolbar-item-navigation > li > a')),
-    testLink: element(by.css('.selected a')),
+    usernameInput: element(by.id('id_username')),
+    passwordInput: element(by.id('id_password')),
+    loginButton: element(by.css('input[type="submit"]')),
+    userMenus: element.all(by.css('.cms-toolbar-item-navigation > li > a')),
 
     // adding new page
+    modalCloseButton: element(by.css('.cms-modal-close')),
     userMenuDropdown: element(by.css(
-        '.cms_toolbar-item-navigation-hover')),
+        '.cms-toolbar-item-navigation-hover')),
     administrationOptions: element.all(by.css(
-        '.cms_toolbar-item-navigation a[href="/en/admin/"]')),
-    sideMenuIframe: element(by.css('.cms_sideframe-frame iframe')),
+        '.cms-toolbar-item-navigation a[href="/en/admin/"]')),
+    sideMenuIframe: element(by.css('.cms-sideframe-frame iframe')),
     pagesLink: element(by.css('.model-page > th > a')),
     addConfigsButton: element(by.css('.object-tools .addlink')),
     addPageLink: element(by.css('.sitemap-noentry .addlink')),
     titleInput: element(by.id('id_title')),
     slugErrorNotification: element(by.css('.errors.slug')),
     saveButton: element(by.css('.submit-row [name="_save"]')),
-    editPageLink: element(by.css('.col1 [href*="preview/"]')),
+    editPageLink: element(by.css('.col-preview [href*="preview/"]')),
+    testLink: element(by.cssContainingText('a', 'Test')),
+    sideFrameClose: element(by.css('.cms-sideframe-close')),
 
     // adding new group
+    breadcrumbs: element(by.css('.breadcrumbs')),
     breadcrumbsLinks: element.all(by.css('.breadcrumbs a')),
     groupsLink: element(by.css(
         '.model-group > th > [href*="/aldryn_people/group/"]')),
@@ -49,17 +50,19 @@ var peoplePage = {
 
     // adding new people entry
     addPersonButton: element(by.css('.model-person .addlink')),
+    editPersonButton: element(by.css('.model-person .changelink')),
+    editPersonLinksTable: element(by.css('.results')),
     editPersonLinks: element.all(by.css(
         '.results th > [href*="/aldryn_people/person/"]')),
 
     // adding people block to the page
     aldrynPeopleBlock: element(by.css('.aldryn-people')),
     advancedSettingsOption: element(by.css(
-        '.cms_toolbar-item-navigation [href*="advanced-settings"]')),
-    modalIframe: element(by.css('.cms_modal-frame iframe')),
+        '.cms-toolbar-item-navigation [href*="advanced-settings"]')),
+    modalIframe: element(by.css('.cms-modal-frame iframe')),
     applicationSelect: element(by.id('application_urls')),
     peopleOption: element(by.css('option[value="PeopleApp"]')),
-    saveModalButton: element(by.css('.cms_modal-buttons .cms_btn-action')),
+    saveModalButton: element(by.css('.cms-modal-buttons .cms-btn-action')),
     peopleEntryLink: element(by.css('.aldryn-people-article > h2 > a')),
     personTitle: element(by.css('.aldryn-people-detail h2 > div')),
 
@@ -73,26 +76,34 @@ var peoplePage = {
         credentials = credentials ||
             { username: 'admin', password: 'admin' };
 
-        peoplePage.usernameInput.clear();
+        page.usernameInput.clear();
 
         // fill in email field
-        return peoplePage.usernameInput.sendKeys(credentials.username)
-            .then(function () {
-            peoplePage.passwordInput.clear();
+        page.usernameInput.sendKeys(
+            credentials.username).then(function () {
+            page.passwordInput.clear();
 
             // fill in password field
-            return peoplePage.passwordInput.sendKeys(credentials.password);
+            return page.passwordInput.sendKeys(
+                credentials.password);
         }).then(function () {
-            peoplePage.loginButton.click();
+            return page.loginButton.click();
+        }).then(function () {
+            // this is required for django1.6, because it doesn't redirect
+            // correctly from admin
+            browser.get(page.site);
 
             // wait for user menu to appear
-            cmsProtractorHelper.waitFor(peoplePage.userMenus.first());
+            browser.wait(browser.isElementPresent(
+                page.userMenus.first()),
+                page.mainElementsWaitTime);
 
             // validate user menu
-            expect(peoplePage.userMenus.first().isDisplayed()).toBeTruthy();
+            expect(page.userMenus.first().isDisplayed())
+                .toBeTruthy();
         });
     }
 
 };
 
-module.exports = peoplePage;
+module.exports = page;

--- a/aldryn_people/tests/frontend/integration/specs/spec.people.crud.js
+++ b/aldryn_people/tests/frontend/integration/specs/spec.people.crud.js
@@ -20,17 +20,13 @@ describe('Aldryn People tests: ', function () {
         browser.get(peoplePage.site);
 
         // check if the page already exists
-        return peoplePage.testLink.isPresent().then(function (present) {
+        peoplePage.testLink.isPresent().then(function (present) {
             if (present === true) {
                 // go to the main page
                 browser.get(peoplePage.site + '?edit');
-            } else {
-                // click edit mode link
-                peoplePage.editModeLink.click();
+                browser.sleep(1000);
+                cmsProtractorHelper.waitForDisplayed(peoplePage.usernameInput);
             }
-
-            // wait for username input to appear
-            cmsProtractorHelper.waitFor(peoplePage.usernameInput);
 
             // login to the site
             peoplePage.cmsLogin();
@@ -38,6 +34,17 @@ describe('Aldryn People tests: ', function () {
     });
 
     it('creates a new test page', function () {
+        // close the wizard if necessary
+        peoplePage.modalCloseButton.isDisplayed().then(function (displayed) {
+            if (displayed) {
+                peoplePage.modalCloseButton.click();
+            }
+        });
+
+        cmsProtractorHelper.waitForDisplayed(peoplePage.userMenus.first());
+        // have to wait till animation finished
+        browser.sleep(300);
+
         // click the example.com link in the top menu
         return peoplePage.userMenus.first().click().then(function () {
             // wait for top menu dropdown options to appear
@@ -50,7 +57,7 @@ describe('Aldryn People tests: ', function () {
 
             // switch to sidebar menu iframe
             browser.switchTo().frame(browser.findElement(
-                By.css('.cms_sideframe-frame iframe')));
+                By.css('.cms-sideframe-frame iframe')));
 
             cmsProtractorHelper.waitFor(peoplePage.pagesLink);
 
@@ -108,13 +115,18 @@ describe('Aldryn People tests: ', function () {
 
                 // switch to sidebar menu iframe
                 return browser.switchTo().frame(browser.findElement(By.css(
-                    '.cms_sideframe-frame iframe')));
+                    '.cms-sideframe-frame iframe')));
             }
         }).then(function () {
-            cmsProtractorHelper.waitFor(peoplePage.breadcrumbsLinks.first());
+            browser.sleep(1000);
 
-            // click the Home link in breadcrumbs
-            peoplePage.breadcrumbsLinks.first().click();
+            peoplePage.breadcrumbs.isPresent().then(function (present) {
+                if (present) {
+                    // click the Home link in breadcrumbs
+                    cmsProtractorHelper.waitFor(peoplePage.breadcrumbsLinks.first());
+                    peoplePage.breadcrumbsLinks.first().click();
+                }
+            });
 
             cmsProtractorHelper.waitFor(peoplePage.groupsLink);
 
@@ -132,27 +144,12 @@ describe('Aldryn People tests: ', function () {
 
                 peoplePage.addConfigsButton.click();
 
-                cmsProtractorHelper.waitFor(peoplePage.englishLanguageTab);
+                cmsProtractorHelper.waitFor(peoplePage.nameInput);
 
-                // switch to English language tab
-                return peoplePage.englishLanguageTab.click().then(function () {
-                    cmsProtractorHelper.waitFor(peoplePage.nameInput);
-
-                    return peoplePage.nameInput.sendKeys('Test group');
-                }).then(function () {
+                peoplePage.nameInput.sendKeys('Test group').then(function () {
                     browser.actions().mouseMove(
                         peoplePage.saveAndContinueButton).perform();
                     peoplePage.saveButton.click();
-
-                    // wait for page to get auto reloaded
-                    browser.sleep(1000);
-
-                    // wait for modal iframe to appear
-                    cmsProtractorHelper.waitFor(peoplePage.sideMenuIframe);
-
-                    // switch to sidebar menu iframe again as the page was reloaded
-                    return browser.switchTo().frame(browser.findElement(By.css(
-                        '.cms_sideframe-frame iframe')));
                 }).then(function () {
                     // wait for group link to appear
                     cmsProtractorHelper.waitFor(peoplePage.editConfigsLink);
@@ -175,33 +172,20 @@ describe('Aldryn People tests: ', function () {
 
         peoplePage.addPersonButton.click();
 
-        cmsProtractorHelper.waitFor(peoplePage.englishLanguageTab);
+        cmsProtractorHelper.waitFor(peoplePage.nameInput);
 
-        // switch to English language tab
-        return peoplePage.englishLanguageTab.click().then(function () {
-            cmsProtractorHelper.waitFor(peoplePage.nameInput);
-
-            return peoplePage.nameInput.sendKeys(personName);
-        }).then(function () {
+        peoplePage.nameInput.sendKeys(personName).then(function () {
             cmsProtractorHelper.waitFor(peoplePage.saveAndContinueButton);
 
             browser.actions().mouseMove(peoplePage.saveAndContinueButton)
                 .perform();
             peoplePage.saveButton.click();
-
-            // wait for page to get auto reloaded
-            browser.sleep(1000);
-
-            // wait for modal iframe to appear
-            cmsProtractorHelper.waitFor(peoplePage.sideMenuIframe);
-
-            // switch to sidebar menu iframe again as the page was reloaded
-            return browser.switchTo().frame(browser.findElement(By.css(
-                '.cms_sideframe-frame iframe')));
         }).then(function () {
             // wait for person link to appear
-            cmsProtractorHelper.waitFor(peoplePage.editPersonLinks.first());
+            cmsProtractorHelper.waitFor(peoplePage.successNotification);
 
+            // validate success notification
+            expect(peoplePage.successNotification.isDisplayed()).toBeTruthy();
             // validate edit person link
             expect(peoplePage.editPersonLinks.first().isDisplayed())
                 .toBeTruthy();
@@ -212,7 +196,13 @@ describe('Aldryn People tests: ', function () {
         // go to the main page
         browser.get(peoplePage.site);
 
+        // switch to default page content
+        browser.switchTo().defaultContent();
+
         cmsProtractorHelper.waitFor(peoplePage.testLink);
+
+        // wait till animation finishes
+        browser.sleep(300);
 
         // add people to the page only if it was not added before
         return peoplePage.aldrynPeopleBlock.isPresent().then(function (present) {
@@ -229,7 +219,7 @@ describe('Aldryn People tests: ', function () {
 
                     // switch to modal iframe
                     browser.switchTo().frame(browser.findElement(By.css(
-                        '.cms_modal-frame iframe')));
+                        '.cms-modal-frame iframe')));
 
                     // set People Application
                     cmsProtractorHelper.selectOption(peoplePage.applicationSelect,
@@ -252,6 +242,16 @@ describe('Aldryn People tests: ', function () {
             // wait for link to appear in aldryn people block
             cmsProtractorHelper.waitFor(peoplePage.peopleEntryLink);
 
+            // wait till animation of sideframe opening finishes
+            browser.sleep(300);
+
+            // close sideframe (it covers the link)
+            cmsProtractorHelper.waitFor(peoplePage.sideFrameClose);
+            peoplePage.sideFrameClose.click();
+
+            // wait till animation finishes
+            browser.sleep(300);
+
             peoplePage.peopleEntryLink.click();
 
             cmsProtractorHelper.waitFor(peoplePage.personTitle);
@@ -262,18 +262,33 @@ describe('Aldryn People tests: ', function () {
     });
 
     it('deletes people entry', function () {
-        // wait for modal iframe to appear
-        cmsProtractorHelper.waitFor(peoplePage.sideMenuIframe);
+        cmsProtractorHelper.waitForDisplayed(peoplePage.userMenus.first());
+        // have to wait till animation finished
+        browser.sleep(300);
+        // click the example.com link in the top menu
+        peoplePage.userMenus.first().click().then(function () {
+            // wait for top menu dropdown options to appear
+            cmsProtractorHelper.waitForDisplayed(peoplePage.userMenuDropdown);
+
+            return peoplePage.administrationOptions.first().click();
+        }).then(function () {
+            // wait for modal iframe to appear
+            cmsProtractorHelper.waitFor(peoplePage.sideMenuIframe);
+        });
 
         // switch to sidebar menu iframe
         browser.switchTo()
-            .frame(browser.findElement(By.css('.cms_sideframe-frame iframe')));
+            .frame(browser.findElement(By.css('.cms-sideframe-frame iframe')));
 
-        // wait for edit people entry link to appear
-        cmsProtractorHelper.waitFor(peoplePage.editPersonLinks.first());
-
-        // validate edit people entry links texts to delete proper people entry
-        return peoplePage.editPersonLinks.first().getText().then(function (text) {
+        cmsProtractorHelper.waitFor(peoplePage.editPersonButton);
+        browser.sleep(100);
+        peoplePage.editPersonButton.click().then(function () {
+            // wait for edit job opening link to appear
+            return cmsProtractorHelper.waitFor(peoplePage.editPersonLinksTable);
+        }).then(function () {
+            // validate edit people entry links texts to delete proper people entry
+            return peoplePage.editPersonLinks.first().getText();
+        }).then(function (text) {
             // wait till horizontal scrollbar will disappear and
             // editPersonLinks will become clickable
             browser.sleep(1500);

--- a/aldryn_people/tests/frontend/protractor.conf.js
+++ b/aldryn_people/tests/frontend/protractor.conf.js
@@ -20,8 +20,7 @@ var config = {
 
     // Capabilities to be passed to the webdriver instance
     capabilities: {
-        'browserName': 'phantomjs',
-        'phantomjs.binary.path': require('phantomjs').path
+        'browserName': 'chrome'
     },
 
     onPrepare: function () {
@@ -36,7 +35,8 @@ var config = {
 
     jasmineNodeOpts: {
         showColors: true,
-        defaultTimeoutInterval: 240000
+        defaultTimeoutInterval: 240000,
+        realtimeFailure: true
     }
 
 };

--- a/test_settings.py
+++ b/test_settings.py
@@ -4,6 +4,11 @@ from __future__ import unicode_literals
 
 import django
 
+from distutils.version import LooseVersion
+from cms import __version__ as cms_string_version
+
+cms_version = LooseVersion(cms_string_version)
+
 HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
@@ -110,7 +115,7 @@ HELPER_SETTINGS = {
 
 # This set of MW classes should work for Django 1.6 and 1.7.
 MIDDLEWARE_CLASSES_16_17 = [
-    'aldryn_apphook_reload.middleware.ApphookReloadMiddleware',
+    'cms.middleware.utils.ApphookReloadMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -125,7 +130,7 @@ MIDDLEWARE_CLASSES_16_17 = [
 ]
 
 MIDDLEWARE_CLASSES_18 = [
-    'aldryn_apphook_reload.middleware.ApphookReloadMiddleware',
+    'cms.middleware.utils.ApphookReloadMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -147,6 +152,14 @@ if django_version.startswith('1.6.') or django_version.startswith('1.7.'):
     HELPER_SETTINGS['MIDDLEWARE_CLASSES'] = MIDDLEWARE_CLASSES_16_17
 elif django_version.startswith('1.8.'):
     HELPER_SETTINGS['MIDDLEWARE_CLASSES'] = MIDDLEWARE_CLASSES_18
+
+# If using CMS 3.2+, use the CMS middleware for ApphookReloading, otherwise,
+# use aldryn_apphook_reload's.
+if cms_version < LooseVersion('3.2.0'):
+    HELPER_SETTINGS['MIDDLEWARE_CLASSES'].remove(
+        'cms.middleware.utils.ApphookReloadMiddleware')
+    HELPER_SETTINGS['MIDDLEWARE_CLASSES'].insert(
+        0, 'aldryn_apphook_reload.middleware.ApphookReloadMiddleware')
 
 
 def run():

--- a/test_settings.py
+++ b/test_settings.py
@@ -50,6 +50,7 @@ HELPER_SETTINGS = {
         'filer.thumbnail_processors.scale_and_crop_with_subject_location',
         'easy_thumbnails.processors.filters',
     ),
+    'CMS_PERMISSION': True,
     'ALDRYN_BOILERPLATE_NAME': 'bootstrap3',
     'LANGUAGES': (
         ('en', 'English'),


### PR DESCRIPTION
- changes tests so they work with 3.2
    - sideframe is now covering most of the view so it has to be opened/closed
    - admin behaviour changed slightly
    - selectors changed
    - added additional safety waits
- change the default local runner from phantomjs to chrome because literally nothing works in phantom (and http://www.protractortest.org/#/browser-support)
- add CMS_PERMISSION setting, because apparently there is a bug in the 3.2 that hides the Pages menu item if it's not set