### PR TITLE
Simplify templates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+
+1.2.0 (UNRELEASED)
+-------------------
+
+* Remove unused render_placeholder configs
+* Add static_placeholders where necessary
+* Simplify templates
+
+
 1.1.6 (2016-02-11)
 -------------------
 

--- a/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/base.html
+++ b/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/base.html
@@ -1,0 +1,3 @@
+{% extends CMS_TEMPLATE %}
+
+{% block content %}{% endblock content %}

--- a/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/fullwidth.html
+++ b/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/fullwidth.html
@@ -1,0 +1,18 @@
+{% extends "aldryn_people/base.html" %}
+{% load i18n cms_tags %}
+
+{% block content %}
+    <div class="container">
+        <div class="row">
+            <div class="col-md-16 col-md-push-4">
+                <div class="aldryn aldryn-people">
+                    {% block people_content %}{% endblock %}
+                </div>
+            </div>
+        </div>
+
+        <div class="aldryn aldryn-people">
+            {% block people_footer %}{% endblock %}
+        </div>
+    </div>
+{% endblock content %}

--- a/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/group_detail.html
+++ b/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/group_detail.html
@@ -1,15 +1,13 @@
-{% extends "base.html" %}
+{% extends "aldryn_people/fullwidth.html" %}
 {% load cms_tags i18n %}
 
 {% block title %}{{ group.name }} - {{ block.super }}{% endblock %}
 
-{% block content %}
+{% block people_content %}
     <div class="aldryn aldryn-people aldryn-group-detail">
-        {% static_placeholder "people_detail_top" %}
         <h2>{% render_model group "name" %}</h2>
         {% for person in group.people.all|dictsort:"name" %}
             {% include "aldryn_people/includes/person.html" with person=person %}
         {% endfor %}
-        {% static_placeholder "people_detail_bottom" %}
     </div>
-{% endblock content %}
+{% endblock people_content %}

--- a/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/group_list.html
+++ b/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/group_list.html
@@ -1,9 +1,8 @@
-{% extends "base.html" %}
+{% extends "aldryn_people/fullwidth.html" %}
 {% load cms_tags i18n %}
 
-{% block content %}
+{% block people_content %}
     <div class="aldryn aldryn-people aldryn-group-list">
-        {% static_placeholder "people_groups_top" %}
         {% for group in group_list %}
             <h2>{% render_model group 'name' %}</h2>
             {% for person in group.people.all|dictsort:"name" %}
@@ -16,6 +15,5 @@
                 {% include "aldryn_people/includes/person.html" with person=person %}
             {% endfor %}
         {% endif %}
-        {% static_placeholder "people_groups_bottom" %}
     </div>
-{% endblock content %}
+{% endblock people_content %}

--- a/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/includes/person.html
+++ b/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/includes/person.html
@@ -1,30 +1,27 @@
 {% load cms_tags i18n thumbnail aldryn_people_tags %}
+{% load url from future %}
 
 <article class="aldryn-people-article">
+    {% if person.visual %}
+        <p class="visual">
+            {% if instance.show_links %}
+                <a href="{{ person.get_absolute_url }}">
+            {% endif %}
+                <img src="{% thumbnail person.visual 400x300 crop subject_location=person.visual.subject_location %}" alt="{{ person.name }}">
+            {% if instance.show_links %}
+                </a>
+            {% endif %}
+        </p>
+    {% endif %}
+
     {% if not group %}<h2>{% else %}<h3>{% endif %}
         {% if not detail_view %}
-            {% if person.get_absolute_url %}
-                <a href="{{ person.get_absolute_url }}">{{ person.name }}</a>
-            {% else %}
-                {{ person.name }}
-            {% endif %}
+            <a href="{{ person.get_absolute_url }}">{{ person.name }}</a>
         {% else %}
             {% render_model person 'name' %}
         {% endif %}
         <small>{{ person.function }}</small>
     {% if not group %}</h2>{% else %}</h3>{% endif %}
-
-    {% if person.visual %}
-        <p class="visual">
-            {% if instance.show_links and person.get_absolute_url %}
-                <a href="{{ person.get_absolute_url }}">
-            {% endif %}
-                <img src="{% thumbnail person.visual 200x100 crop subject_location=person.visual.subject_location %}" alt="{{ person.name }}">
-            {% if instance.show_links and person.get_absolute_url %}
-                </a>
-            {% endif %}
-        </p>
-    {% endif %}
 
     <p class="meta">
         {% if person.phone %}
@@ -50,6 +47,7 @@
             <a href="{{ person.website }}" target="_blank">{{ person.website }}</a><br>
         {% endif %}
     </p>
+
     {% if person.description %}
         <div class="lead">{{ person.description|safe }}</div>
     {% endif %}

--- a/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/includes/person.html
+++ b/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/includes/person.html
@@ -1,5 +1,4 @@
 {% load cms_tags i18n thumbnail aldryn_people_tags %}
-{% load url from future %}
 
 <article class="aldryn-people-article">
     {% if person.visual %}

--- a/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/person_detail.html
+++ b/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/person_detail.html
@@ -1,10 +1,10 @@
-{% extends "base.html" %}
+{% extends "aldryn_people/fullwidth.html" %}
 {% load i18n %}
 
 {% block title %}{{ person.name }} - {{ block.super }}{% endblock %}
 
-{% block content %}
+{% block people_content %}
     <div class="aldryn aldryn-people aldryn-people-detail">
         {% include "aldryn_people/includes/person.html" with person=person detail_view="true" %}
     </div>
-{% endblock content %}
+{% endblock people_content %}

--- a/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/plugins/standard/people_list.html
+++ b/aldryn_people/boilerplates/bootstrap3/templates/aldryn_people/plugins/standard/people_list.html
@@ -1,9 +1,6 @@
 {% load i18n %}
 
 <div class="aldryn aldryn-people">
-    {% if namespace_error and request.user.is_superuser or request.user.is_staff %}
-        <span class="people-error">{{ namespace_error }}</span>
-    {% endif %}
     {% if not people_groups %}
         {# if grouping is disabled, list only people #}
         <div class="aldryn-people-list">

--- a/aldryn_people/tests/frontend/integration/pages/page.people.crud.js
+++ b/aldryn_people/tests/frontend/integration/pages/page.people.crud.js
@@ -63,8 +63,8 @@ var page = {
     applicationSelect: element(by.id('application_urls')),
     peopleOption: element(by.css('option[value="PeopleApp"]')),
     saveModalButton: element(by.css('.cms-modal-buttons .cms-btn-action')),
-    peopleEntryLink: element(by.css('.aldryn-people-article > h2 > a')),
-    personTitle: element(by.css('.aldryn-people-detail h2 > div')),
+    peopleEntryLink: element(by.css('article > h2 > a')),
+    personTitle: element(by.css('article h2 > div')),
 
     // deleting people entry
     deleteButton: element(by.css('.deletelink-box a')),

--- a/aldryn_people/tests/frontend/integration/pages/page.people.crud.js
+++ b/aldryn_people/tests/frontend/integration/pages/page.people.crud.js
@@ -28,11 +28,11 @@ var page = {
     sideMenuIframe: element(by.css('.cms-sideframe-frame iframe')),
     pagesLink: element(by.css('.model-page > th > a')),
     addConfigsButton: element(by.css('.object-tools .addlink')),
-    addPageLink: element(by.css('.sitemap-noentry .addlink')),
+    addPageLink: element(by.css('.object-tools .addlink')),
     titleInput: element(by.id('id_title')),
     slugErrorNotification: element(by.css('.errors.slug')),
     saveButton: element(by.css('.submit-row [name="_save"]')),
-    editPageLink: element(by.css('.col-preview [href*="preview/"]')),
+    editPageLink: element(by.css('.cms-tree-item-preview [href*="preview/"]')),
     testLink: element(by.cssContainingText('a', 'Test')),
     sideFrameClose: element(by.css('.cms-sideframe-close')),
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -55,7 +55,6 @@ HELPER_SETTINGS = {
         'easy_thumbnails.processors.filters',
     ),
     'CMS_PERMISSION': True,
-    'ALDRYN_BOILERPLATE_NAME': 'bootstrap3',
     'LANGUAGES': (
         ('en', 'English'),
         ('de', 'German'),
@@ -149,7 +148,7 @@ if cms_version < LooseVersion('3.2.0'):
 
 def run():
     from djangocms_helper import runner
-    runner.cms('aldryn_people', extra_args=['--boilerplate'])
+    runner.cms('aldryn_people', extra_args=[])
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
The goal of this Pull Request is:

- Simplify template structure
- Remove unnecessary placeholder and blocks
- In general make everything simple for easier explanation

We also want to remove ``render_placeholder view.config`` and later only mention it in the documentation (separate PR will follow).