### PR TITLE
changes name and slug fields to full width

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-1.2.01 (2016-xx-xx)
+1.2.1 (2016-xx-xx)
 -------------------
 
 * Changes name and slug fields in admin to full width

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+1.2.01 (2016-xx-xx)
+-------------------
+
+* Changes name and slug fields in admin to full width
+
 
 1.2.0 (2016-03-10)
 -------------------

--- a/aldryn_people/admin.py
+++ b/aldryn_people/admin.py
@@ -61,7 +61,8 @@ class PersonAdmin(VersionedPlaceholderAdminMixin,
     fieldsets = (
         (None, {
             'fields': (
-                ('name', 'slug', ),
+                'name',
+                'slug',
                 'function', 'description',
             ),
         }),
@@ -98,7 +99,8 @@ class GroupAdmin(VersionedPlaceholderAdminMixin,
     fieldsets = (
         (None, {
             'fields': (
-                ('name', 'slug', ),
+                'name',
+                'slug',
                 'description',
             ),
         }),


### PR DESCRIPTION
**This pull request fixes the following issues**:

- changes name and slug fields in admin add groups and people

|BEFORE|AFTER|
|---|---|
|![screen shot 2016-04-07 at 14 04 48](https://cloud.githubusercontent.com/assets/2270884/14350574/89d9e3a0-fcca-11e5-9fbb-1943895ba0c0.png)|![screen shot 2016-04-07 at 14 08 57](https://cloud.githubusercontent.com/assets/2270884/14350585/999601d4-fcca-11e5-9c79-f2b41626227b.png)|

