### PR TITLE
Fix person wizard to save group.

### DIFF
--- a/aldryn_people/cms_wizards.py
+++ b/aldryn_people/cms_wizards.py
@@ -88,12 +88,13 @@ class CreatePeoplePersonForm(BaseFormMixin, TranslatableModelForm):
                 self.save_m2m()
                 if self.user:
                     revision_context_manager.set_user(self.user)
+                object_repr = build_obj_repr(person)
+                translation_info = get_translation_info_message(person)
                 revision_context_manager.set_comment(
-                    ugettext("Initial version of {0}. {1}".format(
-                        build_obj_repr(person),
-                        get_translation_info_message(person)
-                    )))
-
+                    ugettext(
+                        "Initial version of {object_repr}. {trans_info}".format(
+                            object_repr=object_repr,
+                            trans_info=translation_info)))
         return person
 
 
@@ -115,11 +116,13 @@ class CreatePeopleGroupForm(BaseFormMixin, TranslatableModelForm):
                 group.save()
                 if self.user:
                     revision_context_manager.set_user(self.user)
+                object_repr = build_obj_repr(group)
+                translation_info = get_translation_info_message(group)
                 revision_context_manager.set_comment(
-                    ugettext("Initial version of {0}. {1}".format(
-                        build_obj_repr(group),
-                        get_translation_info_message(group)
-                    )))
+                    ugettext(
+                        "Initial version of {object_repr}. {trans_info}".format(
+                            object_repr=object_repr,
+                            trans_info=translation_info)))
 
         return group
 

--- a/aldryn_people/cms_wizards.py
+++ b/aldryn_people/cms_wizards.py
@@ -12,7 +12,9 @@ from cms.wizards.forms import BaseFormMixin
 
 from parler.forms import TranslatableModelForm
 from reversion.revisions import revision_context_manager
-
+from aldryn_reversion.utils import (
+    build_obj_repr, get_translation_info_message,
+)
 from .models import Group, Person
 
 
@@ -83,10 +85,14 @@ class CreatePeoplePersonForm(BaseFormMixin, TranslatableModelForm):
         with transaction.atomic():
             with revision_context_manager.create_revision():
                 person.save()
+                self.save_m2m()
                 if self.user:
                     revision_context_manager.set_user(self.user)
                 revision_context_manager.set_comment(
-                    ugettext("Initial version."))
+                    ugettext("Initial version of {0}. {1}".format(
+                        build_obj_repr(person),
+                        get_translation_info_message(person)
+                    )))
 
         return person
 
@@ -110,7 +116,10 @@ class CreatePeopleGroupForm(BaseFormMixin, TranslatableModelForm):
                 if self.user:
                     revision_context_manager.set_user(self.user)
                 revision_context_manager.set_comment(
-                    ugettext("Initial version."))
+                    ugettext("Initial version of {0}. {1}".format(
+                        build_obj_repr(group),
+                        get_translation_info_message(group)
+                    )))
 
         return group
 

--- a/aldryn_people/locale/de/LC_MESSAGES/django.po
+++ b/aldryn_people/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-17 16:48+0200\n"
+"POT-Creation-Date: 2016-04-20 15:46+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: admin.py:68 admin.py:105
+#: admin.py:69 admin.py:107
 msgid "Contact (untranslated)"
 msgstr ""
 
-#: admin.py:88
+#: admin.py:89
 msgid "# Groups"
 msgstr ""
 
-#: admin.py:120
+#: admin.py:122
 msgid "# People"
 msgstr ""
 
@@ -145,23 +145,24 @@ msgstr ""
 msgid "Edit person"
 msgstr ""
 
-#: cms_wizards.py:89 cms_wizards.py:113
-msgid "Initial version."
+#: cms_wizards.py:95 cms_wizards.py:123
+#, python-brace-format
+msgid "Initial version of {object_repr}. {trans_info}"
 msgstr ""
 
-#: cms_wizards.py:119
+#: cms_wizards.py:131
 msgid "New person"
 msgstr ""
 
-#: cms_wizards.py:122
+#: cms_wizards.py:134
 msgid "Create a new person."
 msgstr ""
 
-#: cms_wizards.py:129
+#: cms_wizards.py:141
 msgid "New group"
 msgstr ""
 
-#: cms_wizards.py:132
+#: cms_wizards.py:144
 msgid "Create a new group."
 msgstr ""
 

--- a/aldryn_people/locale/en/LC_MESSAGES/django.po
+++ b/aldryn_people/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-17 16:48+0200\n"
+"POT-Creation-Date: 2016-04-20 15:46+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,15 +17,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: admin.py:68 admin.py:105
+#: admin.py:69 admin.py:107
 msgid "Contact (untranslated)"
 msgstr ""
 
-#: admin.py:88
+#: admin.py:89
 msgid "# Groups"
 msgstr ""
 
-#: admin.py:120
+#: admin.py:122
 msgid "# People"
 msgstr ""
 
@@ -144,23 +144,24 @@ msgstr ""
 msgid "Edit person"
 msgstr ""
 
-#: cms_wizards.py:89 cms_wizards.py:113
-msgid "Initial version."
+#: cms_wizards.py:95 cms_wizards.py:123
+#, python-brace-format
+msgid "Initial version of {object_repr}. {trans_info}"
 msgstr ""
 
-#: cms_wizards.py:119
+#: cms_wizards.py:131
 msgid "New person"
 msgstr ""
 
-#: cms_wizards.py:122
+#: cms_wizards.py:134
 msgid "Create a new person."
 msgstr ""
 
-#: cms_wizards.py:129
+#: cms_wizards.py:141
 msgid "New group"
 msgstr ""
 
-#: cms_wizards.py:132
+#: cms_wizards.py:144
 msgid "Create a new group."
 msgstr ""
 

--- a/aldryn_people/locale/fr/LC_MESSAGES/django.po
+++ b/aldryn_people/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-17 16:48+0200\n"
+"POT-Creation-Date: 2016-04-20 15:46+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: admin.py:68 admin.py:105
+#: admin.py:69 admin.py:107
 msgid "Contact (untranslated)"
 msgstr ""
 
-#: admin.py:88
+#: admin.py:89
 msgid "# Groups"
 msgstr ""
 
-#: admin.py:120
+#: admin.py:122
 msgid "# People"
 msgstr ""
 
@@ -145,23 +145,24 @@ msgstr ""
 msgid "Edit person"
 msgstr ""
 
-#: cms_wizards.py:89 cms_wizards.py:113
-msgid "Initial version."
+#: cms_wizards.py:95 cms_wizards.py:123
+#, python-brace-format
+msgid "Initial version of {object_repr}. {trans_info}"
 msgstr ""
 
-#: cms_wizards.py:119
+#: cms_wizards.py:131
 msgid "New person"
 msgstr ""
 
-#: cms_wizards.py:122
+#: cms_wizards.py:134
 msgid "Create a new person."
 msgstr ""
 
-#: cms_wizards.py:129
+#: cms_wizards.py:141
 msgid "New group"
 msgstr ""
 
-#: cms_wizards.py:132
+#: cms_wizards.py:144
 msgid "Create a new group."
 msgstr ""
 

--- a/aldryn_people/locale/it/LC_MESSAGES/django.po
+++ b/aldryn_people/locale/it/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-17 16:48+0200\n"
+"POT-Creation-Date: 2016-04-20 15:46+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: admin.py:68 admin.py:105
+#: admin.py:69 admin.py:107
 msgid "Contact (untranslated)"
 msgstr ""
 
-#: admin.py:88
+#: admin.py:89
 msgid "# Groups"
 msgstr ""
 
-#: admin.py:120
+#: admin.py:122
 msgid "# People"
 msgstr ""
 
@@ -145,23 +145,24 @@ msgstr ""
 msgid "Edit person"
 msgstr ""
 
-#: cms_wizards.py:89 cms_wizards.py:113
-msgid "Initial version."
+#: cms_wizards.py:95 cms_wizards.py:123
+#, python-brace-format
+msgid "Initial version of {object_repr}. {trans_info}"
 msgstr ""
 
-#: cms_wizards.py:119
+#: cms_wizards.py:131
 msgid "New person"
 msgstr ""
 
-#: cms_wizards.py:122
+#: cms_wizards.py:134
 msgid "Create a new person."
 msgstr ""
 
-#: cms_wizards.py:129
+#: cms_wizards.py:141
 msgid "New group"
 msgstr ""
 
-#: cms_wizards.py:132
+#: cms_wizards.py:144
 msgid "Create a new group."
 msgstr ""
 


### PR DESCRIPTION
If ``commit=False`` then ``form.save_m2m()`` should be called to save m2m fields.

Also adjust the reversion message to be more informative, otherwise it will be unusable for the group history.