### PR TITLE
People List plugin: fix download vcard error if no apphook present.

### DIFF
--- a/aldryn_people/templates/aldryn_people/includes/person.html
+++ b/aldryn_people/templates/aldryn_people/includes/person.html
@@ -52,7 +52,7 @@
         {{ person.description|safe }}
     {% endif %}
 
-    {% if not instance and person.vcard_enabled or instance.show_vcard and person.vcard_enabled %}
+    {% if not instance and person.vcard_enabled or instance.show_vcard and person.vcard_enabled and person.get_vcard_url %}
         <a href="{{ person.get_vcard_url }}">
             {% trans "Download vCard" %}
         </a>

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+toxworkdir = {homedir}/.toxenvs/aldryn-people
 envlist =
     flake8
     py{34,27}-dj19-cms32


### PR DESCRIPTION
If plugin was created with ``show_vacard = True`` and there was no apphook it was producing a 500 error. This PR fixes the issue + some test cases.