### PR TITLE
Use CMS 3.5 releases while testing, update supported Django versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Requirements
 
 * Python 2.7, 3.3, 3.4, 3.5
 * django CMS 3.2 or later
-* Django 1.8 - 1.10
+* Django 1.8 - 1.11
 
 
 .. |PyPI Version| image:: https://badge.fury.io/py/aldryn_people.svg

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps =
     cms34: django-cms>=3.4,<3.5
     cms34: djangocms-text-ckeditor>=3.0,<3.1
 
-    cms35: https://github.com/divio/django-cms/archive/develop.zip
+    cms35: django-cms>=3.5,<3.6
     cms35: djangocms-text-ckeditor>=3.0
 
 basepython =


### PR DESCRIPTION
…es instead of current develop